### PR TITLE
画像のリクエストタイミング変更

### DIFF
--- a/grayscale/js/index.js
+++ b/grayscale/js/index.js
@@ -7,7 +7,6 @@
 			var canvas = document.createElement('canvas');
 			var canvasContext = canvas.getContext('2d');
 			var img = new Image();
-			img.src = selector.attr("src");
 			img.onload = function () {
 				var imgW = img.width;
 				var imgH = img.height;
@@ -30,6 +29,7 @@
 				canvasContext.putImageData(imgPixels, 0, 0, 0, 0, imgPixels.width, imgPixels.height);
 				selector.attr("src", canvas.toDataURL());
 			};
+			img.src = selector.attr("src");
 		}
 	});
 })();


### PR DESCRIPTION
読込完了イベントハンドラ登録前にリクエストを実行していたため。イベントハンドラ登録後にリクエストするよう修正。

以下は参考URLとなります。
http://please-sleep.cou929.nu/onload-handler-setting-timing-and-async-request-of-image-element.html